### PR TITLE
Use sock._closed to determine is_alive for telnet connections

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -570,7 +570,7 @@ class BaseConnection:
         and not telnet. Therefore to handle telnet remote_Conn, this function is created a wrapper
         """
         if self.protocol == "telnet":
-            return not self.is_alive()
+            return self.remote_conn.sock._closed
         else:
             return self.remote_conn.closed
         


### PR DESCRIPTION
With netmiko4 deployment, some some errors in vxr bake which uses haconnection.py of cafykit to connect. 
Some runs failed https://techzone.cisco.com/t5/IOS-XR-PI-CQE-INFRA-Eng/quot-Failed-to-exit-configuration-mode-quot-and-quot/td-p/8774145
The reason is telnet connection uses IAC+NOP to determine if session is_alive. this IAP+NOP is causing errors like 
```
RP/0/RP0/CPU0:R2#

Invalid number(-15) sent as ASCII value to command-line process from VTY/TTY, refreshing prompt.
RP/0/RP0/CPU0:R2#
```
which interferes with the router prompt and therefore encountering PatternNotFoundException


The fix is to use remote_conn.sock._closed argument to check if session is_alive instead of sending IAC+NOP

PAss logs:
allure.cisco.com/ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_vxr_20230612-154107_p15730/reports/index.html

Fail logs:
http://allure.cisco.com/ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_vxr_20230612-142858_p20374/reports/index.html
