### PR TITLE
define session_preparation() in vxr_ssh

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1725,7 +1725,7 @@ before timing out.\n"""
                     raise SessionDownException(msg)
             else:
                 msg = f"""
-Pattern not found in output after sending command and waiting for {read_timeout} seconds. 
+Pattern not found in output after sending cmd {command_string} and waiting for {read_timeout} seconds. 
 Expected Pattern: {repr(search_pattern)}
 Output: {repr(output)}
 You can also look at the Netmiko session_log for more information.

--- a/netmiko/cisco/cisco_vxr_ssh.py
+++ b/netmiko/cisco/cisco_vxr_ssh.py
@@ -40,6 +40,15 @@ class CiscoVxrSSH(CiscoXrSSH):
         kwargs["blocking_timeout"] = self.read_timeout
         super().__init__(**kwargs)
 
+    def session_preparation(self) -> None:
+        """Prepare the session after the connection has been established."""
+        # IOS-XR has an issue where it echoes the command even though it hasn't returned the prompt
+        self._test_channel_read(pattern=r"[>#]")
+        cmd = "terminal width 511"
+        self.set_terminal_width(command=cmd, pattern=cmd)
+        self.disable_paging()
+        self.set_base_prompt()
+
     def write_channel(self, out_data):
         """Generic handler that will write to both SSH and telnet channel.
 


### PR DESCRIPTION
Issue is:
```
2023-06-14 12:20:40,061 Debug--- disable_paging [R1-> 172.26.228.14:64853] In disable_paging
2023-06-14 12:20:40,061 Debug--- disable_paging [R1-> 172.26.228.14:64853] Command: terminal length 0

2023-06-14 12:20:40,062 Debug--- wrapper_decorator [R1-> 172.26.228.14:64853] write_channel: b'terminal length 0\n'
2023-06-14 12:20:40,062 Debug--- read_until_pattern [R1-> 172.26.228.14:64853] In read_until_pattern, read_timeout: 1800, blocking_timeout: 1800, pattern is: terminal\ length\ 0
2023-06-14 12:20:40,062 Debug--- read_channel [R1-> 172.26.228.14:64853] read_channel:
2023-06-14 12:20:40,163 Info---- read_until_pattern [R1-> 172.26.228.14:64853] Pattern not found. Time waited: 2.384185791015625e-07
2023-06-14 12:20:40,163 Debug--- read_channel [R1-> 172.26.228.14:64853] read_channel: terminal length 0

Wed Jun 14 19:20:39.736 UTC
RP/0/RP0/CPU0:ios#
2023-06-14 12:20:40,164 Info---- read_until_pattern [R1-> 172.26.228.14:64853] Pattern found. Time Waited: 0.10102176666259766.
2023-06-14 12:20:40,164 Debug--- disable_paging [R1-> 172.26.228.14:64853] terminal length 0

Wed Jun 14 19:20:39.736 UTC
RP/0/RP0/CPU0:ios#
2023-06-14 12:20:40,164 Debug--- disable_paging [R1-> 172.26.228.14:64853] Exiting disable_paging
2023-06-14 12:20:40,164 Debug--- read_until_pattern [R1-> 172.26.228.14:64853] In read_until_pattern, read_timeout: 1800, blocking_timeout: 1800, pattern is: [>#]
2023-06-14 12:20:40,164 Debug--- read_channel [R1-> 172.26.228.14:64853] read_channel:
2023-06-14 12:20:40,265 Info---- read_until_pattern [R1-> 172.26.228.14:64853] Pattern not found. Time waited: 2.384185791015625e-07
2023-06-14 12:20:40,265 Debug--- read_channel [R1-> 172.26.228.14:64853] read_channel:
2023-06-14 12:20:40,365 Info---- read_until_pattern [R1-> 172.26.228.14:64853] Pattern not found. Time waited: 0.10075688362121582
2023-06-14 12:20:40,366 Debug--- read_channel [R1-> 172.26.228.14:64853] read_channel:
2023-06-14 12:20:40,466 Info---- read_until_pattern [R1-> 172.26.228.14:64853] Pattern not found. Time waited: 0.20138931274414062
2023-06-14 12:20:40,466 Debug--- read_channel [R1-> 172.26.228.14:64853] read_channel:
2023-06-14 12:20:40,566 Info---- read_until_pattern [R1-> 172.26.228.14:64853] Pattern not found. Time waited: 0.30194664001464844 
```
/auto/tftp-aj-sjc/cafy/branch/cafykit/work/archive/oc_qos_auto_two_ut_script_20230614-124651_p18906/

the RC is https://github.com/cafykit/netmiko-v4/blob/0460c28f30dc8cb319f04dbc182da3b8b97e8603/netmiko/cisco/cisco_xr.py#L24
and the difference between the read_until_pattern() definition in vxr_ssh and base_Connection
read_until_pattern() in base_connection only reads upto pattern and returns upto that pattern whereas this function in vxr_ssh return the entire output. 
solution is to Define session_preparation()  in vxr_Ssh

Pass logs: allure.cisco.com/ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_console_20230614-150734_p1019559/reports/index.html


