### PR TITLE
Add check to receive router prompt after teminal width 511 cmd

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -660,6 +660,7 @@ results={results}
                 if buffer:
                     self._read_buffer += buffer
                 self.log.debug(f"Pattern found: {pattern} in output: {output}")
+                self.log.debug(f"Extra buffer read: {buffer}")
                 return output
             time.sleep(loop_delay)
 

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -1725,7 +1725,7 @@ before timing out.\n"""
                     raise SessionDownException(msg)
             else:
                 msg = f"""
-Pattern not found in output after sending command and waiting for {read_timeout} seconds. 
+Pattern not found in output after sending cmd {command_string} and waiting for {read_timeout} seconds. 
 Expected Pattern: {repr(search_pattern)}
 Output: {repr(output)}
 You can also look at the Netmiko session_log for more information.

--- a/netmiko/cisco/cisco_vxr_ssh.py
+++ b/netmiko/cisco/cisco_vxr_ssh.py
@@ -40,6 +40,15 @@ class CiscoVxrSSH(CiscoXrSSH):
         kwargs["blocking_timeout"] = self.read_timeout
         super().__init__(**kwargs)
 
+    def session_preparation(self) -> None:
+        """Prepare the session after the connection has been established."""
+        # IOS-XR has an issue where it echoes the command even though it hasn't returned the prompt
+        self._test_channel_read(pattern=r"[>#]")
+        cmd = "terminal width 511"
+        self.set_terminal_width(command=cmd, pattern=cmd)
+        self.disable_paging()
+        self.set_base_prompt()
+
     def write_channel(self, out_data):
         """Generic handler that will write to both SSH and telnet channel.
 

--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -321,6 +321,7 @@ class CiscoXrTelnet(CiscoXrBase):
             return
         cmd = "terminal width 511"
         self.set_terminal_width(command=cmd, pattern=cmd)
+        self._test_channel_read(pattern=r"[>#]")
         self.disable_paging()
         self._test_channel_read(pattern=r"[>#]")
         


### PR DESCRIPTION
Fail log: https://firex-west.cisco.com/auto/firex-logs-sjc/adsakthi/FireX-adsakthi-230615-061728-10029/tests_logs/sff_run_E8D64638/script_console_output.txt

The reason is with console handle, in CiscoXrTelnet, after cmd "terminal width 511" is sent, it takes few timer ticks to get the router prompt back, but the cmd transaction is terminated successfully because its echo is seen. after that 'terminal length 0' is sent, during its read_Channel, xr prompt is seen which the code mistakes it as the success condition of this https://github.com/cafykit/netmiko-v4/blob/14103fa7dc6b1597b1ed278da18e4c62ea08ac13/netmiko/cisco/cisco_xr.py#L325
and after that, the unsynchronization build up which results in the above failed log error

Fix: add the explicit check to see if router prompt is received after "terminal width 511" cmd is sent.
PAss logs: allure.cisco.com/ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_console_20230615-130944_p1470638/reports/index.html