### PR TITLE
Add check to receive router prompt after teminal width 511 cmd

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -660,6 +660,7 @@ results={results}
                 if buffer:
                     self._read_buffer += buffer
                 self.log.debug(f"Pattern found: {pattern} in output: {output}")
+                self.log.debug(f"Extra buffer read: {buffer}")
                 return output
             time.sleep(loop_delay)
 

--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -321,6 +321,7 @@ class CiscoXrTelnet(CiscoXrBase):
             return
         cmd = "terminal width 511"
         self.set_terminal_width(command=cmd, pattern=cmd)
+        self._test_channel_read(pattern=r"[>#]")
         self.disable_paging()
         self._test_channel_read(pattern=r"[>#]")
         


### PR DESCRIPTION
Fail log: https://firex-west.cisco.com/auto/firex-logs-sjc/adsakthi/FireX-adsakthi-230615-061728-10029/tests_logs/sff_run_E8D64638/script_console_output.txt

The reason is with console handle, in CiscoXrTelnet, after cmd "terminal width 511" is sent, it takes few timer ticks to get the router prompt back, but the cmd transaction is terminated successfully because its echo is seen. after that 'terminal length 0' is sent, during its read_Channel, xr prompt is seen which the code mistakes it as the success condition of this

[netmiko-v4/netmiko/cisco/cisco_xr.py](https://github.com/cafykit/netmiko-v4/blob/14103fa7dc6b1597b1ed278da18e4c62ea08ac13/netmiko/cisco/cisco_xr.py#L325)

Line 325 in [14103fa](https://github.com/cafykit/netmiko-v4/commit/14103fa7dc6b1597b1ed278da18e4c62ea08ac13)

 self._test_channel_read(pattern=r"[>#]") 

and after that, the unsynchronization build up which results in the above failed log error
Fix: add the explicit check to see if router prompt is received after "terminal width 511" cmd is sent.
PAss logs: allure.cisco.com/ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_console_20230615-130944_p1470638/reports/index.html