### PR TITLE
normalize_line_feeds arg

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -187,7 +187,8 @@ class BaseConnection:
         auto_connect: bool = True,
         delay_factor_compat: bool = False,
         max_read_timeout: Optional[int] = None,
-        device_name=None
+        device_name=None,
+        disable_lf_normalization: bool = False,
     ) -> None:
         """
         Initialize attributes for establishing connection to target device.
@@ -290,6 +291,9 @@ class BaseConnection:
         :param delay_factor_compat: Set send_command and send_command_timing back to using Netmiko
                 3.x behavior for delay_factor/global_delay_factor/max_loops. This argument will be
                 eliminated in Netmiko 5.x (default: False).
+
+        :param disable_lf_normalization: Disable Netmiko's linefeed normalization behavior
+                (default: False)
         """
 
         self.remote_conn: Union[
@@ -311,6 +315,7 @@ class BaseConnection:
 
         # Line Separator in response lines
         self.RESPONSE_RETURN = "\n" if response_return is None else response_return
+        self.disable_lf_normalization = True if disable_lf_normalization else False
         if ip:
             self.host = ip.strip()
         elif host:
@@ -442,7 +447,7 @@ class BaseConnection:
         # Establish the remote connection
         if auto_connect:
             self._open()
-
+             
     def _open(self) -> None:
         """Decouple connection creation from __init__ for mocking."""
         self._modify_connection_params()
@@ -579,7 +584,18 @@ class BaseConnection:
     def read_channel(self) -> str:
         """Generic handler that will read all the data from given channel."""
         new_data = self.channel.read_channel()
-        new_data = self.normalize_linefeeds(new_data)
+        if self.disable_lf_normalization is False:
+            start = time.time()
+            # Data blocks shouldn't end in '\r' (can cause problems with normalize_linefeeds)
+            # Only do the extra read if '\n' exists in the output
+            # this avoids devices that only use \r.
+            while ("\n" in new_data) and (time.time() - start < 1.0):
+                if new_data[-1] == "\r":
+                    time.sleep(0.01)
+                    new_data += self.channel.read_channel()
+                else:
+                    break
+            new_data = self.normalize_linefeeds(new_data)
         if self.ansi_escape_codes:
             new_data = self.strip_ansi_escape_codes(new_data)
         self.log.debug(f"read_channel: {new_data}")
@@ -660,7 +676,6 @@ results={results}
                 if buffer:
                     self._read_buffer += buffer
                 self.log.debug(f"Pattern found: {pattern} in output: {output}")
-                self.log.debug(f"Extra buffer read: {buffer}")
                 return output
             time.sleep(loop_delay)
 
@@ -1006,7 +1021,6 @@ You can look at the Netmiko session_log or debug log for more information.
     ) -> str:
         """Strip out command echo and trailing router prompt."""
         if strip_command and command_string:
-            command_string = self.normalize_linefeeds(command_string)
             output = self.strip_command(command_string, output)
         if strip_prompt:
             output = self.strip_prompt(output)
@@ -1726,7 +1740,7 @@ before timing out.\n"""
                     raise SessionDownException(msg)
             else:
                 msg = f"""
-Pattern not found in output after sending cmd {command_string} and waiting for {read_timeout} seconds. 
+Pattern not found in output after sending command {command_string} and waiting for {read_timeout} seconds. 
 Expected Pattern: {repr(search_pattern)}
 Output: {repr(output)}
 You can also look at the Netmiko session_log for more information.

--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -676,6 +676,7 @@ results={results}
                 if buffer:
                     self._read_buffer += buffer
                 self.log.debug(f"Pattern found: {pattern} in output: {output}")
+                self.log.debug(f"Extra buffer read: {buffer}")
                 return output
             time.sleep(loop_delay)
 
@@ -1740,7 +1741,7 @@ before timing out.\n"""
                     raise SessionDownException(msg)
             else:
                 msg = f"""
-Pattern not found in output after sending command {command_string} and waiting for {read_timeout} seconds. 
+Pattern not found in output after sending cmd {command_string} and waiting for {read_timeout} seconds. 
 Expected Pattern: {repr(search_pattern)}
 Output: {repr(output)}
 You can also look at the Netmiko session_log for more information.


### PR DESCRIPTION
https://techzone.cisco.com/t5/IOS-XR-PI-CQE-INFRA-Eng/With-netmiko4-facing-issue-with-show-interfaces-output-as-it-s/td-p/9060641
show_interfaces produce a big output that is concatenated via a newline from multiple read_Channel() outputs. this newline causes issue in the show_interfaces parser and fails there

This is a known issue in netmiko-4
https://github.com/ktbyers/netmiko/pull/3193

PAss logs with fix:
http://allure.cisco.com/ws/dhlad-sjc/netmiko_failure/my_file_20230630-164626_p11741/reports/index.html