### PR TITLE
create cisco_vxr_telnet device type and modify its TELNET_RETURN

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -309,7 +309,10 @@ class BaseConnection:
             if "telnet" not in device_type:
                 self.RETURN = "\n"
             else:
-                self.RETURN = self.TELNET_RETURN
+                if device_type == "cisco_vxr_telnet":
+                    self.RETURN = "\n"
+                else:
+                    self.RETURN = self.TELNET_RETURN
         else:
             self.RETURN = default_enter
 

--- a/netmiko/cisco/__init__.py
+++ b/netmiko/cisco/__init__.py
@@ -9,7 +9,7 @@ from netmiko.cisco.cisco_ios import InLineTransfer
 from netmiko.cisco.cisco_asa_ssh import CiscoAsaSSH, CiscoAsaFileTransfer
 from netmiko.cisco.cisco_ftd_ssh import CiscoFtdSSH
 from netmiko.cisco.cisco_nxos_ssh import CiscoNxosSSH, CiscoNxosFileTransfer
-from netmiko.cisco.cisco_xr import CiscoXrSSH, CiscoXrTelnet, CiscoXrFileTransfer, CiscoCxrHa
+from netmiko.cisco.cisco_xr import CiscoXrSSH, CiscoXrTelnet, CiscoXrFileTransfer, CiscoCxrHa, CiscoVxrTelnet
 from netmiko.cisco.cisco_wlc_ssh import CiscoWlcSSH
 from netmiko.cisco.cisco_s300 import CiscoS300SSH
 from netmiko.cisco.cisco_s300 import CiscoS300Telnet
@@ -44,5 +44,6 @@ __all__ = [
     "CiscoCloudnativeSSH",
     "CiscoCloudnativeTelnet",
     "CiscoCxrHa",
-    "CiscoVxrSSH"
+    "CiscoVxrSSH",
+    "CiscoVxrTelnet"
 ]

--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -380,6 +380,8 @@ class CiscoXrTelnet(CiscoXrBase):
         self.base_prompt = prompt[:-1]
         return self.base_prompt
     
+class CiscoVxrTelnet(CiscoXrTelnet):
+   pass
 
 class CiscoXrFileTransfer(CiscoFileTransfer):
     """Cisco IOS-XR SCP File Transfer driver."""

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -35,7 +35,7 @@ from netmiko.cisco import CiscoTpTcCeSSH
 from netmiko.cisco import CiscoViptelaSSH
 from netmiko.cisco import CiscoWlcSSH
 from netmiko.cisco import CiscoXrSSH, CiscoXrTelnet, CiscoXrFileTransfer
-from netmiko.cisco import CiscoVxrSSH
+from netmiko.cisco import CiscoVxrSSH, CiscoVxrTelnet
 from netmiko.cisco import CiscoCloudnativeSSH
 from netmiko.cisco import CiscoCxrHa
 from netmiko.citrix import NetscalerSSH
@@ -287,6 +287,7 @@ CLASS_MAPPER["ciena_saos_telnet"] = CienaSaosTelnet
 CLASS_MAPPER["cisco_ios_telnet"] = CiscoIosTelnet
 CLASS_MAPPER["cisco_xr_telnet"] = CiscoXrTelnet
 CLASS_MAPPER["cisco_xe_telnet"] = CiscoIosTelnet
+CLASS_MAPPER["cisco_vxr_telnet"] = CiscoVxrTelnet
 CLASS_MAPPER["cisco_s300_telnet"] = CiscoS300Telnet
 CLASS_MAPPER["cisco_cxr_ha_telnet"] = CiscoCxrHa
 CLASS_MAPPER["cisco_bsp_telnet"] = CiscoBspTelnet


### PR DESCRIPTION
 this is VxrTelnet discrepancy in evaluating '\r\n' which is the default TELENT_RETURN  defined in the code. For hardware telnet handles, this is evaluated as expected, but for Vxr telnet, '\r\n' gets evaluated as 2 newline chars. Therefore, following issue is seen
-https://techzone.cisco.com/t5/IOS-XR-PI-CQE-INFRA-Eng/Script-fails-to-exit-configuration-mode-post-commit-replace/m-p/9085997

PAss logs:
allure.cisco.com/ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_commit_replace_20230706-153329_p10681/reports/index.html