### PR TITLE
Make sure the entire config prompt is read when entering config mode

### DIFF
--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -251,6 +251,21 @@ class CiscoXrBase(CiscoBaseConnection):
         output = output.replace("(admin)", "")
         return check_string in output
 
+    def config_mode(
+        self,
+        config_command: str = "config terminal",
+        pattern: str = "",
+        re_flags: int = 0,
+    ) -> str:
+        if not pattern:
+            # Make sure the *entire* config prompt is read.
+            pattern = re.escape(self.base_prompt[:16])
+            check_string = re.escape(")#")
+            pattern = f"{pattern}.*{check_string}"
+        return super().config_mode(
+            config_command=config_command, pattern=pattern, re_flags=re_flags
+        )
+
     def exit_config_mode(self, exit_config: str = "end", pattern: str = "", skip_check=False) -> str:
         """Exit configuration mode."""
         output = ""


### PR DESCRIPTION
## Issue summary

If the first config line written after entering config mode is invalid, then `ConfigInvalidException` is intermittently **not** raised.

This applies to Cisco IOS-XR platforms.

A minimal repro is at https://github.com/tjohnes/cafykit-netmiko-v4-example.

## Root cause

`CiscoBaseConnection.config_mode` expects a pattern of the base prompt, truncated to 16 chars.  This was added in 902936fd8d1fd247d40e3bfc5601428c675c0eee.

The problem is that this does not read the entire config prompt when entering config mode.

`BaseConnection.config_mode` then calls `CiscoXrBase.check_config_mode`, which sends a newline and expects `r"[#\$]"`.  This matches the end of the what's already in the extra buffer and so returns immediately.

The first config line is then intermittently written before the second config prompt; this results in a netmiko session log like this:

```
RP/0/RP0/CPU0:ios#config terminal

Thu Aug 17 20:25:27.043 UTC
RP/0/RP0/CPU0:ios(config)#

zzz
RP/0/RP0/CPU0:ios(config)#zzz

                           ^
% Invalid input detected at '^' marker.
RP/0/RP0/CPU0:ios(config)#
```

When `cmd_verify` is set, we read until the first `zzz`; and then we read until the next prompt (the second prompt).  The `output` (according to `BaseConnection.send_config_set`) is therefore:

```
config terminal

Thu Aug 17 20:44:21.989 UTC
RP/0/RP0/CPU0:io

zzz
RP/0/RP0/CPU0:ios(config)#zzz
```

which does not contain the expected "Invalid input" string.

This is evident from the debug logs (truncated somewhat for brevity):

```
DEBUG    netmiko:base_connection.py:116 [None] write_channel: b'config terminal\n'
DEBUG    netmiko:base_connection.py:604 [None] read_channel: config terminal
DEBUG    netmiko:base_connection.py:681 [None] Pattern found: (config\ terminal) in output: config terminal
DEBUG    netmiko:base_connection.py:604 [None] read_channel: RP/0/RP0/CPU0:ios(config)#
DEBUG    netmiko:base_connection.py:681 [None] Pattern found: (RP/0/RP0/CPU0:io) in output:
DEBUG    netmiko:base_connection.py:116 [None] write_channel: b'\n'
DEBUG    netmiko:base_connection.py:681 [None] Pattern found: ([#\$]) in output: s(config)#
DEBUG    netmiko:base_connection.py:116 [None] write_channel: b'zzz\n'
DEBUG    netmiko:base_connection.py:604 [None] read_channel:

zzz
RP/0/RP0/CPU0:ios(config)#zzz

                           ^
% Invalid input detected at '^' marker.
RP/0/RP0/CPU0:ios(config)#
DEBUG    netmiko:base_connection.py:681 [None] Pattern found: (zzz) in output:

zzz
DEBUG    netmiko:base_connection.py:681 [None] Pattern found: ((?:RP/0/RP0/CPU0:ios.*$|#.*$)) in output:
RP/0/RP0/CPU0:ios(config)#zzz
```

## Description of the fix

Override `config_mode` for `CiscoXrBase` to read the entire config prompt when entering config mode.

This is very similar to the approach taken (in upstream netmiko) for `AristaBase.config_mode`.

## Testing

https://github.com/tjohnes/cafykit-netmiko-v4-example no longer reproduces the issue when this fix is present.