### PR TITLE
remove base character being looked for 16 char to avoid ncs4k issues

### DIFF
--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -251,21 +251,6 @@ class CiscoXrBase(CiscoBaseConnection):
         output = output.replace("(admin)", "")
         return check_string in output
 
-    def config_mode(
-        self,
-        config_command: str = "config terminal",
-        pattern: str = "",
-        re_flags: int = 0,
-    ) -> str:
-        if not pattern:
-            # Make sure the *entire* config prompt is read.
-            pattern = re.escape(self.base_prompt[:16])
-            check_string = re.escape(")#")
-            pattern = f"{pattern}.*{check_string}"
-        return super().config_mode(
-            config_command=config_command, pattern=pattern, re_flags=re_flags
-        )
-
     def exit_config_mode(self, exit_config: str = "end", pattern: str = "", skip_check=False) -> str:
         """Exit configuration mode."""
         output = ""

--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -38,8 +38,6 @@ class CiscoBaseConnection(BaseConnection):
 
         Cisco IOS devices abbreviate the prompt at 20 chars in config mode
         """
-        if not pattern:
-            pattern = self.base_prompt[:14]
         return super().check_config_mode(check_string=check_string, pattern=pattern)
 
     def config_mode(
@@ -48,8 +46,6 @@ class CiscoBaseConnection(BaseConnection):
         pattern: str = "",
         re_flags: int = 0,
     ) -> str:
-        if not pattern:
-            pattern = re.escape(self.base_prompt[:16])
         return super().config_mode(
             config_command=config_command, pattern=pattern, re_flags=re_flags
         )


### PR DESCRIPTION
```
Regarding the configuration prompt pattern mismatch issue in ncs4k which I posted in cafy infra space,I went through the exception stack and found that the issue falls in file cisco_xr.py ,complete path of that file is:
/auto/cafy/release/23.37.10/rhel7-23.37.10/lib/python3.6/site-packages/netmiko/cisco/cisco_xr.
 
In this file , we have a function config_mode(),
 
def config_mode(
        self,
        config_command: str = "config terminal",
        pattern: str = "",
        re_flags: int = 0,
    ) -> str:
        if not pattern:
            # Make sure the *entire* config prompt is read.
            pattern = re.escape(self.base_prompt[:16])
            check_string = re.escape(")#")
            pattern = f"{pattern}.*{check_string}"
        return super().config_mode(
            config_command=config_command, pattern=pattern, re_flags=re_flags
        )
 
 
+++   pattern = re.escape(self.base_prompt[:16]) >>>>>>> here this line is taking first 16 characters of base prompt which is the XR prompt

In other XR devices and first 16 characters of base prompt are marked as below –
 
RP/0/RP0/CPU0:R1#



So, for config prompt check condition ,the pattern becomes "RP/0/RP0/CPU0:R" .* ")#" which matches config prompt “RP/0/RP0/CPU0:R1(config)#”
 
Since in NCS4k prompt we do not have /CPU0,thus taking first 16 characters do not work here :
RP/0/RP0:R1#   
 
So, for config prompt check the pattern becomes "RP/0/RP0/CPU0:R1#" .* ")#". Which obviously fails to match and hence the error:
 
 “
 PatternNotDetected: ‘RP\\/0\\/RP0\\:R1\#.*\\)\\#' in output.
Output: '\n\nTue Oct 24 12:44:22.384 IST\nRP/0/RP0:R1(config)#'.
 
“
 
Just to validate it further, I have increased characters in my hostname to 16 (or more) characters of ncs 4k device and with this change it is working fine and im able to make config changes using star.
 
 Therefore, it is imperative to implement modifications within the 'cisco_xr.py' file to ensure its compatibility with NCS 4K platform. Could you please suggest appropriate team or individual who can assist in resolving this issue ?
 
 
 
Also, fyr ,I do not see this config_mode function in latest cisco_xr.py file.
 
https://github.com/ktbyers/netmiko/blob/develop/netmiko/cisco/cisco_xr.py
 
I ran a basic netmiko script earlier to check if I see the config prompt issue just using netmiko libraries and it worked perfectly without throwing any pattern error.
 
 
from netmiko import Netmiko
devices = [{
   "device_type": "cisco_xr",
   "ip": "10.106.201.222",
   "username": "root",
   "password": "lab",
  
}]
description = 'Description set with Netmiko'
description_config = [
    "interface tenGigE 0/8/0/8/1",
    f"description {description}",
    "commit"
]
for device in devices:
   net_connect = Netmiko(**device)
   output = net_connect.send_config_set(description_config)
   print(output)
   net_connect.disconnect()
   ```

Revert both https://github.com/cafykit/netmiko-v4/commit/902936fd8d1fd247d40e3bfc5601428c675c0eee(https://github.com/cafykit/netmiko-v4/pull/26