### PR TITLE
bring back this code but removing :16 from base_prompt

### DIFF
--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -24,6 +24,21 @@ class CiscoXrBase(CiscoBaseConnection):
         self._test_channel_read(pattern=r"[>#]")
         self.set_base_prompt()
 
+    def config_mode(
+        self,
+        config_command: str = "config terminal",
+        pattern: str = "",
+        re_flags: int = 0,
+    ) -> str:
+        if not pattern:
+            # Make sure the *entire* config prompt is read.
+            pattern = re.escape(self.base_prompt)
+            check_string = re.escape(")#")
+            pattern = f"{pattern}.*{check_string}"
+        return super().config_mode(
+            config_command=config_command, pattern=pattern, re_flags=re_flags
+        )
+
     def send_config_set(
         self,
         config_commands: Union[str, Sequence[str], TextIO, None] = None,


### PR DESCRIPTION
when the console is too slow the following issue is seen
https://cafy3.cisco.com/report/1489059/1989041
http://ott-idt-jenk1:8080/job/test_cafyap_bake/83907/consoleFull
```
-Error----2023-11-26T17-22-52.904[R1_bake][HaConnection]> Connect function on console failed: Failed to enter configuration mode.
-Info-----2023-11-26T17-22-52.907[R1_bake][HaConnection]> disconnecting ACTIVE.. console
-Info-----2023-11-26T17-22-52.908[R1_bake][HaConnection]> Already disconnected STANDBY console
-Info-----2023-11-26T17-22-52.908[R1_bake][sleep]> Waiting for disconnect: sleeping for 15 seconds
-Info-----2023-11-26T17-23-07.923[R1_bake][sleep]> Waiting for disconnect: resuming after 15 seconds 
-Error----2023-11-26T17-23-07.926[R1_bake][bake]> Bake failed for R1. Exception: Failed to enter configuration mode.
Traceback (most recent call last):
  File "/auto/cafy/infra_framework/cafykit/lib/hw/bake/bake.py", line 51, in bake_box
    _bake_box(device)
  File "/auto/cafy/infra_framework/cafykit/lib/hw/bake/bake.py", line 117, in _bake_box
    Ncs5508Bake(input_dict=device)
  File "/auto/cafy/infra_framework/cafykit/lib/hw/bake/ncs5508_bake.py", line 33, in __init__
    super().__init__(input_dict=input_dict, debug_print=False, timeout=timeout, *args, **kwargs)
  File "/auto/cafy/infra_framework/cafykit/lib/hw/bake/bake_base.py", line 348, in __init__
    raise error
  File "/auto/cafy/infra_framework/cafykit/lib/hw/bake/bake_base.py", line 310, in __init__
    self.image_check()
  File "/auto/cafy/infra_framework/cafykit/lib/hw/bake/ncs5508_bake.py", line 615, in image_check
    self.device_object.connect(handle='console', standby_rp_port=self.standby_rp_port)
  File "/auto/cafy/infra_framework/cafykit/lib/topology/devices/device.py", line 2067, in connect
    handle.connect(*args, containers=containers, **kwargs)
  File "/auto/cafy/infra_framework/cafykit/lib/topology/connection/haconnection.py", line 103, in connect
    raise (e)
  File "/auto/cafy/infra_framework/cafykit/lib/topology/connection/haconnection.py", line 100, in connect
    self._connect(*args, **kwargs)
  File "/auto/cafy/infra_framework/cafykit/lib/topology/connection/haconnection.py", line 167, in _connect
    self._disable_logging_console()
  File "/auto/cafy/infra_framework/cafykit/lib/topology/connection/haconnection.py", line 183, in _disable_logging_console
    self.config(cmd_list=cmd)
  File "/auto/cafy/infra_framework/cafykit/lib/topology/connection/connection.py", line 1091, in config
    raise e
  File "/auto/cafy/infra_framework/cafykit/lib/topology/connection/connection.py", line 1086, in config
    clear_inconsistency = clear_inconsistency)
  File "/auto/cafy/infra_framework/cafykit/lib/topology/connection/connection.py", line 833, in _config
    raise e
  File "/auto/cafy/infra_framework/cafykit/lib/topology/connection/connection.py", line 825, in _config
    read_timeout=read_timeout
  File "/auto/cafy/release/23.47.10/rhel7-23.47.10/lib/python3.6/site-packages/netmiko/cisco/cisco_xr.py", line 35, in send_config_set
    config_commands=config_commands, exit_config_mode=exit_config_mode, **kwargs
  File "/auto/cafy/release/23.47.10/rhel7-23.47.10/lib/python3.6/site-packages/netmiko/base_connection.py", line 2197, in send_config_set
    output += self.config_mode()
  File "/auto/cafy/release/23.47.10/rhel7-23.47.10/lib/python3.6/site-packages/netmiko/cisco_base_connection.py", line 50, in config_mode
    config_command=config_command, pattern=pattern, re_flags=re_flags
  File "/auto/cafy/release/23.47.10/rhel7-23.47.10/lib/python3.6/site-packages/netmiko/base_connection.py", line 2038, in config_mode
    raise ValueError("Failed to enter configuration mode.")
ValueError: Failed to enter configuration mode.
-Error----2023-11-26T17-23-07.960[MainThread][bake]> BAKE_ERROR: Unknown Error
-Info-----2023-11-26T17-23-07.973[MainThread][bake]> +------------------------------------------------------------------------------+
-Info-----2023-11-26T17-23-07.974[MainThread][bake]> |                              Bake Summary Table                              |
-Info-----2023-11-26T17-23-07.974[MainThread][bake]> +------------------------------------------------------------------------------+
-Info-----2023-11-26T17-23-07.974[MainThread][bake]> ========  ==========  ========  ===================================
Device    Platform    Status    Information
========  ==========  ========  ===================================
R1        NCS5508     Fail      Failed to enter configuration mode.
========  ==========  ========  ===================================
```


netmiko.log snippet
```
base_connection.py         118 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] write_channel: b'config terminal\r\n'
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: conf
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: ig terminal
base_connection.py         682 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] Pattern found: (config\ terminal) in output: config terminal
base_connection.py         683 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] Extra buffer read: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 

Sun Nov
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel:  26 22:22:51.
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 570 UTC



base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 

base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: RP/
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 0/RP0/CPU0:pp
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: -5508-r1-p
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: od2(config)
base_connection.py         682 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] Pattern found: (RP\/0\/RP0\/CPU0\:pp\-5508\-r1\-pod2.*) in output: 

Sun Nov 26 22:22:51.570 UTC



RP/0/RP0/CPU0:pp-5508-r1-pod2(config)
base_connection.py         683 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] Extra buffer read: 
base_connection.py         118 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] write_channel: b'\r\n'
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: #
base_connection.py         682 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] Pattern found: ([#\$]) in output: #
base_connection.py         683 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] Extra buffer read: 
base_connection.py         118 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] write_channel: b'\r\n'
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 
base_connection.py         605 Debug--- [pp-5508-r1-pod2-> 10.85.82.127:2003] read_channel: 

```

