### PR TITLE
handle tlent_login if prompt is in config mode

### DIFF
--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -164,7 +164,6 @@ class CiscoBaseConnection(BaseConnection):
                 try:
                     self.log.debug("Reading channel for the first time")
                     output = self.read_channel()
-
                     # This below if block is addeed because when the telnet console starts with UserName,
                     # self.read_channel which internally calls telnetlib.read_ver_eager() returns empty string
                     # So, assign it to self.find_prompt()
@@ -179,6 +178,16 @@ class CiscoBaseConnection(BaseConnection):
                     return_msg += output
 
                     # is at spitfire xr prompt
+
+                    if re.search('RP/\d+/RP\d+/CPU\d+:\S*\)#$', output):
+                        # To check if it is in the config prompt
+                        # If yes, then write newline char, "clear" and "end" to clear any stale configs
+                        self.write_channel(self.TELNET_RETURN + "clear" + self.TELNET_RETURN)
+                        self.read_channel()
+                        self.write_channel("end" + self.TELNET_RETURN)
+                        output = self.find_prompt()
+                        return_msg += output
+
                     if re.search('RP/\d+/RP\d+/CPU\d+:\S*#$', output):
                         return return_msg
 


### PR DESCRIPTION
	1.	The telnet prompt of the router was left in config prompt. How it landed in config prompt is unknown because previous health check job had successfully disconnected console handle. After that, the testbed was assigned for a run 24 hours later. In between these 24 hours, someone logged intot he device and left it in config prompt.
	2.	the telnet connection code when attempts to login to console, it is successful becaiuse it sees xr prompt but it assumes it is on exec prompt and not config prompt. it executes some cmds and makes some configurations which fail while committing because of commit conflict from previous session.

