### PR TITLE
Added SessionDownException handling in is_alive()

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -565,7 +565,7 @@ class BaseConnection:
                 result = self.remote_conn.transport.is_active()
                 assert isinstance(result, bool)
                 return result
-            except (socket.error, EOFError):
+            except (socket.error, EOFError, SessionDownException):
                 log.error("Unable to send", exc_info=True)
                 # If unable to send, we can tell for sure that the connection is unusable
                 return False


### PR DESCRIPTION
is_alive() writes NULL byte to figure out if ssh session is still alive or not.
If its not, write_channel() is base_connection.py will throw either socket.error or EOFError exception (coming from underling paramiko) . these exceptions are caught and False is returned which means session is not alive.

However, write_channel is overriden for CiscoVxrSSH class @ https://github.com/cafykit/netmiko-v4/blob/5dd9cf854cd08561a7523e21d5c8259698cebf19/netmiko/cisco/cisco_vxr_ssh.py#L52 and it catches socket.error and changes the exception to SessionDownException. This creates an issue in is_alive() method where its not handled and it throws back the exception back to connection.py in cafykit -> device -> caller

This PR adds SessionDownException as part of exceptions being caught in is_alive() method

Logs where issue was seen: https://firex-west.cisco.com/auto/firex-logs-sjc-2/smuddavv/FireX-smuddavv-240524-014545-27052/tests_logs/ofainfra_cafy_test_7E3980D/reports/#packages/a3a06087a49ea51e2da9ae9154650077/5c9184488c41e89/

