### PR TITLE
Pass ctrl-q char to unlock it from telnet hung state

### DIFF
--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -123,6 +123,9 @@ class CiscoBaseConnection(BaseConnection):
                     if cxr_pattern in prompt.lower():
                         time.sleep((delay_factor * 0.1) + 3)
                         prompt = self.read_channel()
+                    if count == 5 and not prompt:
+                        self.log.info("Probably in telnet hung state. Passing ctrl-q . Potential DDTS: CSCwh67759 and CSCvy64395")
+                        self.write_channel('\x11')
                 count += 1
 
         # If multiple lines in the output take the last line

--- a/netmiko/cisco_base_connection.py
+++ b/netmiko/cisco_base_connection.py
@@ -123,9 +123,14 @@ class CiscoBaseConnection(BaseConnection):
                     if cxr_pattern in prompt.lower():
                         time.sleep((delay_factor * 0.1) + 3)
                         prompt = self.read_channel()
-                    if count == 5 and not prompt:
+                    if count == 3 and not prompt:
                         self.log.info("Probably in telnet hung state. Passing ctrl-q . Potential DDTS: CSCwh67759 and CSCvy64395")
                         self.write_channel('\x11')
+                        time.sleep(15)
+                        prompt = self.read_channel().strip()
+                        if prompt:
+                            self.log.info(f"Prompt found after passing ctrl-q. Prompt is {prompt}")
+                            break
                 count += 1
 
         # If multiple lines in the output take the last line


### PR DESCRIPTION
There have been multiple runs that have failed in the cleanup stage while connecting to the console via telnet.
The connection to the device is tried for ~15 minutes by sending newline character periodically to see if any prompt is received. However, it is observed that no prompt is received and eventually the job fails. 
this is been confirmed manually as well. 

RC: It seems like the in the previous session, the device was exited after doing ctrl-s. A specific set of sequences (ctrl+s) sent can cause the console to go into flow control enable mode.
By sending out the sequence (ctrl+q) we can disable the flow control. 
Already DDTS are in placed [CSCwh67759](https://cdetsng.cisco.com/webui/#view=CSCwh67759)  or [CSCvy64395](https://cdetsng.cisco.com/webui/#view=CSCvy64395)

How the device landed in flow control enabled state (by sending ctrl-s) is unknown because health check successfully runs on a testbed , brings it online and then is dispatched for a run. Possibilities of human intervention without reserving a testbed. In order to determine this, Eduardo is being notified to create a sytem that can log every telnet login to a device.

Logs of issue in cleanup stage : 
[jenkins_log](http://cafy-web-ott2:8080/job/test_cafyap_cleanup/2695/consoleFull)
[netmiko_log](http://allure.cisco.com/auto/cafy-ott/cafy_log/cafy3/24-6/cafy3-run-2258586/netmiko.log)

Logs after sending ctrl-q: 
[here](http://allure.cisco.com/ws/shreyash-sjc/telnet_hung_ctrl-q_netmiko.log)